### PR TITLE
Rework how capture segments are handled a bit.

### DIFF
--- a/lib/sink_impl.h
+++ b/lib/sink_impl.h
@@ -77,6 +77,7 @@ namespace gr {
       }
     }
 
+
     class sink_impl : public sink {
       private:
       // current data FILE*
@@ -129,6 +130,7 @@ namespace gr {
       std::vector<meta_namespace> d_annotations;
 
       void reset_meta();
+      void init_meta();
 
       void on_command_message(pmt::pmt_t msg);
 


### PR DESCRIPTION
This change corrects for the fact that the block may receive
capture segment info while it is not currently writing a block.
Since capture segments apply to all samples going forward from
when they are received, this change correctly bootstraps the
first capture segment of any new recording with the old capture
segment data.