### PR TITLE
NMEA parsing updates

### DIFF
--- a/apps/sigmf_record.cc
+++ b/apps/sigmf_record.cc
@@ -382,7 +382,7 @@ main(int argc, char *argv[])
 
   // Check what the gain is and set that on the first capture segment
   double gain_at_start = usrp_source->get_gain();
-  file_sink->set_capture_meta(0, "uhd:rx_gain", pmt::mp(gain_at_start));
+  file_sink->set_capture_meta(0, "gr_sigmf:rx_gain", pmt::mp(gain_at_start));
 
   std::cout << "Writing SigMF recording to:" << std::endl;
   std::cout << "  Samples: " << file_sink->get_data_path() << std::endl;

--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -320,12 +320,31 @@ namespace gr {
       uint64_t sample_start = nitems_read(0);
       uint64_t sample_count = 0;
 
-      if(pmt::dict_has_key(msg, LATITUDE) && pmt::dict_has_key(msg, LONGITUDE)) {
-        pmt::pmt_t lat = pmt::dict_ref(msg, LATITUDE, pmt::PMT_NIL);
-        pmt::pmt_t lon = pmt::dict_ref(msg, LONGITUDE, pmt::PMT_NIL);
+      if(pmt::is_true(pmt::dict_ref(msg, GPS_VALID, pmt::PMT_F))) {
+        pmt::pmt_t lat = pmt::dict_ref(msg, GPS_LATITUDE, pmt::PMT_NIL);
+        pmt::pmt_t lon = pmt::dict_ref(msg, GPS_LONGITUDE, pmt::PMT_NIL);
+
         set_annotation_meta(sample_start, sample_count, "core:latitude", lat);
         set_annotation_meta(sample_start, sample_count, "core:longitude", lon);
-        set_annotation_meta(sample_start, sample_count, "core:generator", pmt::string_to_symbol("USRP GPS Message"));
+        set_annotation_meta(sample_start, sample_count, "core:generator", pmt::string_to_symbol("gr_sigmf"));
+
+        std::vector<std::pair<std::string, pmt::pmt_t>> keys;
+        keys.push_back(std::make_pair("gr_sigmf:speed_knots", GPS_SPEED_KNOTS));
+        keys.push_back(std::make_pair("gr_sigmf:track_angle", GPS_TRACK_ANGLE));
+        keys.push_back(std::make_pair("gr_sigmf:magnetic_variation", GPS_MAGNETIC_VARIATION));
+        keys.push_back(std::make_pair("gr_sigmf:fix_quality", GPS_FIX_QUALITY));
+        keys.push_back(std::make_pair("gr_sigmf:num_sats", GPS_NUM_SATS));
+        keys.push_back(std::make_pair("gr_sigmf:hdop", GPS_HDOP));
+        keys.push_back(std::make_pair("gr_sigmf:altitude", GPS_ALTITUDE));
+        keys.push_back(std::make_pair("gr_sigmf:geoid_hae", GPS_GEOID_HAE));
+        keys.push_back(std::make_pair("gr_sigmf:hae", GPS_HAE));
+
+        for (std::pair<std::string, pmt::pmt_t> key: keys) {
+          pmt::pmt_t value = pmt::dict_ref(msg, key.second, pmt::PMT_NIL);
+          if(!pmt::is_null(value)) {
+            set_annotation_meta(sample_start, sample_count, key.first, value);
+          }
+        }
       }
     }
 

--- a/lib/sink_impl.h
+++ b/lib/sink_impl.h
@@ -42,8 +42,20 @@ namespace gr {
     static const pmt::pmt_t COMMAND = pmt::string_to_symbol("command");
     static const pmt::pmt_t GPS = pmt::string_to_symbol("gps");
     static const pmt::pmt_t SYSTEM = pmt::string_to_symbol("system");
-    static const pmt::pmt_t LATITUDE = pmt::string_to_symbol("latitude");
-    static const pmt::pmt_t LONGITUDE = pmt::string_to_symbol("longitude");
+
+    static const pmt::pmt_t GPS_VALID = pmt::string_to_symbol("valid");
+    static const pmt::pmt_t GPS_LATITUDE = pmt::string_to_symbol("latitude");
+    static const pmt::pmt_t GPS_LONGITUDE = pmt::string_to_symbol("longitude");
+    static const pmt::pmt_t GPS_SPEED_KNOTS = pmt::string_to_symbol("speed_knots");
+    static const pmt::pmt_t GPS_TRACK_ANGLE = pmt::string_to_symbol("track_angle");
+    static const pmt::pmt_t GPS_MAGNETIC_VARIATION = pmt::string_to_symbol("magnetic_variation");
+
+    static const pmt::pmt_t GPS_FIX_QUALITY = pmt::string_to_symbol("fix_quality");
+    static const pmt::pmt_t GPS_NUM_SATS = pmt::string_to_symbol("num_sats");
+    static const pmt::pmt_t GPS_HDOP = pmt::string_to_symbol("hdop");
+    static const pmt::pmt_t GPS_ALTITUDE = pmt::string_to_symbol("altitude");
+    static const pmt::pmt_t GPS_GEOID_HAE = pmt::string_to_symbol("geoid_hae");
+    static const pmt::pmt_t GPS_HAE = pmt::string_to_symbol("hae");
 
     inline size_t
     type_to_size(const std::string type)


### PR DESCRIPTION
This branch does the following:
- Uses an extracted NMEA parser (with tests), for increased robustness and support for more fields
- Adds additional fields to the PMT emitted by USRP GPS Message Source
- Reads those fields from the ``gps`` port in the SigMF Sink.
- Records GPS data and receive gain under the ``gr_sigmf:`` namespace.