### PR TITLE
Fix type for timestamp constructor for compatibility with Boost >= 1.67

### DIFF
--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -694,7 +694,7 @@ namespace gr {
             posix::ptime adjusted_time =
               d_relative_start_ts +
               posix::seconds(tag_full_seconds) +
-              posix::nanoseconds(std::floor(tag_frac_seconds * 1000000000));
+              posix::nanoseconds(boost::numeric_cast<uint64_t>(std::floor(tag_frac_seconds * 1000000000)));
             // And set the adjusted time as the new time
             std::string ts_iso = posix::to_iso_extended_string(adjusted_time) + "Z";
             capture_segment.set("core:datetime", ts_iso);


### PR DESCRIPTION
Boost versions 1.67 and later require an integral type for the value of the subsecond duration. This adds a call to `boost::numeric_cast<uint64_t>` to make this work with newer versions of Boost.