### PR TITLE
Include <algorithm> for std::sort() in lib/writer_utils.cc

### DIFF
--- a/lib/writer_utils.cc
+++ b/lib/writer_utils.cc
@@ -1,6 +1,7 @@
 #include "writer_utils.h"
 
 #define RAPIDJSON_HAS_STDSTRING 1
+#include <algorithm>
 #include <rapidjson/document.h>
 #include <rapidjson/filewritestream.h>
 #include <rapidjson/prettywriter.h>


### PR DESCRIPTION
`std::sort()` requires `#include <algorithm>`, at least on F34

Signed-off-by: Jeff Long <willcode4@gmail.com>